### PR TITLE
feat:优化火山岛及特定Boss关卡的按钮阴影高亮偏移

### DIFF
--- a/objects/obj_levelselect_button/Create_0.gml
+++ b/objects/obj_levelselect_button/Create_0.gml
@@ -10,3 +10,12 @@ player_level_require = 0
 pre_level_require = []
 pressed = false
 unlock = false
+
+// 需要额外处理阴影偏移的关卡ID
+special_boss_levels = {
+	"temple": true,
+	"abyss": true,
+	"cheese_castle": true,
+	"macchiato_port": true,
+	"snowcap_volcano": true
+};

--- a/objects/obj_levelselect_button/Draw_0.gml
+++ b/objects/obj_levelselect_button/Draw_0.gml
@@ -2,7 +2,18 @@ draw_self()
 if unlock{
 	image_blend = c_white
 	if on_click{
-		draw_sprite_ext(spr_button_shader_2,0,x,y+5,1.8,1.8,0,c_white,0.3)
+		var shader_x = x;
+		var shader_y = y + 5;
+		
+		if (global.map_id == "volcanic_island") {
+			shader_y -= 2;
+		}
+
+		if (variable_struct_exists(special_boss_levels, target_level_id)) {
+			shader_x += 5;
+			shader_y += 5;
+		}
+		draw_sprite_ext(spr_button_shader_2,0,shader_x,shader_y,1.8,1.8,0,c_white,0.3)
 	}
 }
 else{


### PR DESCRIPTION
神殿/深渊/芝士城堡等boss关卡以及火山岛的关卡的shader覆盖存在偏移，优化了一下火山岛及特定Boss关卡的按钮阴影高亮偏移