### PR TITLE
fix: 修复移动平台移动中放置升级卡误删反方向邻格植物

### DIFF
--- a/objects/obj_card_parent/Other_10.gml
+++ b/objects/obj_card_parent/Other_10.gml
@@ -77,19 +77,7 @@ var grid_pos = get_grid_position_from_world(x, y);
     }
     
     // 获取该网格的植物列表
-    var plant_list = ds_grid_get(global.grid_plants, col, row);
+    // var plant_list = ds_grid_get(global.grid_plants, col, row);
     
-    // 根据植物类型检查是否可以种植
-	if target_card != "none"{
-		for (var i = 0; i < ds_list_size(plant_list); i++) {
-	        var plant = ds_list_find_value(plant_list, i);
-	        if (plant.plant_id == target_card) {
-				
-				if feature_type == "upgrade"{
-					instance_destroy(plant)
-					break
-				}
-				
-	       }
-	    }
-	}
+    // 底座销毁已由obj_card_slot放置逻辑（逻辑格）精确处理；
+    // 此处按视觉位置重复销毁会导致平台移动中误删反方向邻格（已移除）

--- a/objects/obj_platform/Step_2.gml
+++ b/objects/obj_platform/Step_2.gml
@@ -306,8 +306,11 @@ if (id == global._last_platform){
 // 渲染前以x/y为锚点，统一更新所有卡片的grid_col/grid_row和depth
 with (obj_card_parent) {
     var grid_pos = get_grid_position_from_world(x, y)
-    grid_col = grid_pos.col
-    grid_row = grid_pos.row
+    // 平台移动中保留逻辑位置（与obj_card_parent Step_0一致），避免覆盖导致grid与注册脱节
+    if (!(variable_instance_exists(id, "platform_grid_lock") && platform_grid_lock)) {
+        grid_col = grid_pos.col
+        grid_row = grid_pos.row
+    }
     if (variable_instance_exists(id, "plant_type")) {
         var _type = plant_type
         if (object_index == obj_cotton_candy) _type = "lilypad"


### PR DESCRIPTION
在可移动地格（飞艇/浮岛等含移动平台的关卡）上，平台移动动画进行中，将升级卡（大火炉/旋转咖啡壶/加特林小笼包/冰蛋投手/巧克力加农炮/钢鱼刺等）放置到底座卡片上时，除了目标格位的底座被正确升级外，移动方向反方向相邻一格的同种底座也会被误删。
根因：
1. `obj_platform` Step_2 末尾渲染前按视觉坐标重写所有植物的 `grid_col/grid_row`，但未检查 `platform_grid_lock`（与 `obj_card_parent` Step_0 的处理不一致），导致平台移动中植物逻辑格与注册位置脱节；
2. `obj_card_parent` User 0 初始化事件中存在一段重复的底座销毁逻辑，按**创建时的视觉坐标**（含平台移动偏移）定位格子，移动中会定位到反方向邻格，把该格的底座误销毁（正常销毁已由 `obj_card_slot` 放置逻辑按逻辑格精确处理）。

修复：
- `objects/obj_platform/Step_2.gml`：渲染前重算加 `platform_grid_lock` 保护，与 `obj_card_parent` Step_0 一致；
- `objects/obj_card_parent/Other_10.gml`：移除 User 0 中重复的底座销毁逻辑。

验证：飞艇关平台移动中放置升级卡，仅目标格底座被升级，反方向邻格正常保留。

改动：2 个文件，仅 GML 逻辑，无配置/资源改动。