### PR TITLE
备战房卡槽可空选

### DIFF
--- a/objects/obj_battlestart_button/Draw_0.gml
+++ b/objects/obj_battlestart_button/Draw_0.gml
@@ -1,5 +1,5 @@
 draw_self()
-if (not on_click) or instance_exists(obj_quit_confirm) or ds_list_size(global.selected_deck) <= 0{
+if (not on_click) or instance_exists(obj_quit_confirm) or deck_slot_count() <= 0{
 	draw_sprite_ext(spr_battlestart_text,0,x,y,1.8,1.8,0,c_white,1)
 	image_blend = c_white
 }

--- a/objects/obj_battlestart_button/Mouse_4.gml
+++ b/objects/obj_battlestart_button/Mouse_4.gml
@@ -1,5 +1,5 @@
 if on_click and !obj_readyroom_manager.is_submenu_open{
-	if ds_list_size(global.selected_deck) > 0{
+	if deck_slot_count() > 0{
 		button_pushed = true
 		audio_play_sound(snd_button,0,0)
 	}

--- a/objects/obj_deck_clear_btn/Mouse_4.gml
+++ b/objects/obj_deck_clear_btn/Mouse_4.gml
@@ -1,4 +1,4 @@
 if !obj_readyroom_manager.is_submenu_open{
 	audio_play_sound(snd_button,0,0)
-	ds_list_clear(global.selected_deck)
+	clear_deck()
 }

--- a/objects/obj_flame_manager/Draw_0.gml
+++ b/objects/obj_flame_manager/Draw_0.gml
@@ -1,6 +1,6 @@
 
 draw_sprite_ext(spr_flame_indicator,0,350,0,1.8,1.8,0,c_white,1)
-var slot_length = ds_list_size(global.selected_deck)
+var slot_length = deck_slot_count()
 //show_debug_message("slot_length:"+string(slot_length))
 if slot_length <= 14{
 	draw_sprite_ext(spr_slot_top,0,350+83*1.8,0,40+45*(slot_length-1),1.8,0,c_white,1)

--- a/objects/obj_readyroom_manager/Create_0.gml
+++ b/objects/obj_readyroom_manager/Create_0.gml
@@ -8,6 +8,7 @@ instance_create_depth(1700,883,-2,obj_battlestart_button)
 readyroom_music = mus_readyroom
 
 ds_list_clear(global.selected_deck);
+deck_ensure_size();
 //for(var i = 0;i < 21;i++){
 //add_to_deck("xiao_long_bao",0);
 //}

--- a/objects/obj_readyroom_manager/Draw_0.gml
+++ b/objects/obj_readyroom_manager/Draw_0.gml
@@ -172,7 +172,7 @@ for(var i = 0;i<11;i++){
 }
 hover_slot_index = -1
 for(var i = deck_first_slot_index; i < deck_first_slot_index+11;i++){
-	if i < ds_list_size(global.selected_deck){
+	if i < deck_slot_max() && !deck_slot_is_empty(i){
 	var card_id = global.selected_deck[| i][? "card_id"]
 	var card_shape = global.selected_deck[| i][? "shape"]
 	var card_data = global.selected_deck[| i][? "data"]

--- a/objects/obj_readyroom_manager/Draw_64.gml
+++ b/objects/obj_readyroom_manager/Draw_64.gml
@@ -1,5 +1,5 @@
 //绘制悬停提示
-	if (hover_slot_index != -1 && !is_submenu_open) {
+	if (hover_slot_index != -1 && !is_submenu_open && !deck_slot_is_empty(hover_slot_index)) {
 		var card_id = global.selected_deck[| hover_slot_index][? "card_id"]
 		var card_shape = global.selected_deck[| hover_slot_index][? "shape"]
 		var card_data = global.selected_deck[| hover_slot_index][? "data"]

--- a/objects/obj_readyroom_manager/Mouse_53.gml
+++ b/objects/obj_readyroom_manager/Mouse_53.gml
@@ -1,13 +1,15 @@
 if hover_card_index != -1 && !is_submenu_open{
-	if ds_list_size(global.selected_deck) < global.save_data.unlocked_items.max_slot{
+	if deck_slot_first_empty() != -1{
 		audio_play_sound(snd_button,0,0)
 		var card_id = global.player_deck[| hover_card_index*2];
 		add_to_deck(card_id,get_card_info_simple(card_id).shape)
 	}
 }
 if hover_slot_index != -1 && !is_submenu_open{
-	audio_play_sound(snd_button,0,0)
-	ds_list_delete(global.selected_deck,hover_slot_index)
+	if !deck_slot_is_empty(hover_slot_index){
+		audio_play_sound(snd_button,0,0)
+		remove_from_deck(hover_slot_index)
+	}
 }
 if(mouse_x > 785 && mouse_x < 1546 && mouse_y > 762 && mouse_y < 980) && !is_submenu_open{
 	audio_play_sound(snd_button,0,0)

--- a/objects/obj_shovel_slot/Create_0.gml
+++ b/objects/obj_shovel_slot/Create_0.gml
@@ -30,7 +30,7 @@ else{
 }
 
 hotkey = "`";               // 快捷键
-var slot_length = ds_list_size(global.selected_deck)
+var slot_length = deck_slot_count()
 if slot_length <= 14{
 	image_index = 0
 }

--- a/objects/obj_task_manager/Create_0.gml
+++ b/objects/obj_task_manager/Create_0.gml
@@ -104,7 +104,8 @@ function refresh_task_progress(){
 					//遍历卡组，如果没找到相关卡片，则没有携带
 					not_use_designated_card = true
 					for(var k = 0 ; k < ds_list_size(global.selected_deck) ; k++){
-						if array_get_index(limit_card_list,global.selected_deck[| k][? "card_id"]) != -1{
+						if deck_slot_is_empty(k) continue;
+				if array_get_index(limit_card_list,global.selected_deck[| k][? "card_id"]) != -1{
 							not_use_designated_card = false
 						}
 					}

--- a/scripts/add_to_deck/add_to_deck.gml
+++ b/scripts/add_to_deck/add_to_deck.gml
@@ -61,8 +61,8 @@ function deck_empty_slot_ensure() {
 /// @desc 把 selected_deck 补齐到 max_slot 长度（不足追加以 [deck_empty_slot] 占位）
 function deck_ensure_size() {
     deck_empty_slot_ensure();
-    var max = deck_slot_max();
-    while (ds_list_size(global.selected_deck) < max) {
+    var _max = deck_slot_max();
+    while (ds_list_size(global.selected_deck) < _max) {
         ds_list_add(global.selected_deck, global.deck_empty_slot);
     }
 }
@@ -82,8 +82,8 @@ function deck_slot_is_empty(i) {
 function deck_slot_count() {
     deck_ensure_size();
     var n = 0;
-    var max = ds_list_size(global.selected_deck);
-    for (var i = 0; i < max; i++) {
+    var _max = ds_list_size(global.selected_deck);
+    for (var i = 0; i < _max; i++) {
         if (!deck_slot_is_empty(i)) n++;
     }
     return n;
@@ -93,8 +93,8 @@ function deck_slot_count() {
 /// @desc 返回最靠前空槽下标，无空槽返回 -1
 function deck_slot_first_empty() {
     deck_ensure_size();
-    var max = ds_list_size(global.selected_deck);
-    for (var i = 0; i < max; i++) {
+    var _max = ds_list_size(global.selected_deck);
+    for (var i = 0; i < _max; i++) {
         if (deck_slot_is_empty(i)) return i;
     }
     return -1;
@@ -116,10 +116,10 @@ function remove_from_deck(i) {
 /// @function clear_deck()
 /// @desc 清空整个卡组（所有槽位置空，长度保留 max_slot）
 function clear_deck() {
-    var max = deck_slot_max();
+    var _max = deck_slot_max();
     ds_list_clear(global.selected_deck);
     deck_empty_slot_ensure();
-    for (var i = 0; i < max; i++) {
+    for (var i = 0; i < _max; i++) {
         ds_list_add(global.selected_deck, global.deck_empty_slot);
     }
 }

--- a/scripts/add_to_deck/add_to_deck.gml
+++ b/scripts/add_to_deck/add_to_deck.gml
@@ -1,18 +1,125 @@
-/// @function add_to_deck(card_id, shape)
-/// @desc 添加指定形态的卡牌到当前出战卡组
-function add_to_deck(card_id, shape) {
+/// @function add_to_deck(card_id, shape, slot_index)
+/// @desc 添加指定形态的卡牌到当前出战卡组（默认填入最靠前空槽；slot_index>=0 时精确填入该槽）
+function add_to_deck(card_id, shape, slot_index = -1) {
     var card_data = deck_get_card_data(card_id, shape);
-    if (card_data != noone) {
-        // 同时存储卡牌ID和形态信息，以便后续使用
-        var deck_entry = ds_map_create();
-        deck_entry[? "card_id"] = card_id;
-        deck_entry[? "shape"] = shape;
-        deck_entry[? "data"] = card_data;
-        
-        ds_list_add(global.selected_deck, deck_entry);
-		return true
+    if (card_data == noone) return false;
+
+    // 确保卡组槽位已初始化（长度 = max_slot，空槽用 [deck_empty_slot] 占位）
+    deck_ensure_size();
+
+    var deck_entry = ds_map_create();
+    deck_entry[? "card_id"] = card_id;
+    deck_entry[? "shape"] = shape;
+    deck_entry[? "data"] = card_data;
+
+    // 槽位选择：精确填入指定槽（读档还原用）或最靠前空槽
+    var idx = -1;
+    if (slot_index >= 0 && slot_index < ds_list_size(global.selected_deck)) {
+        idx = slot_index;
     }
-	else{
-		return false
-	}
+    else {
+        idx = deck_slot_first_empty();
+    }
+
+    if (idx == -1) { // 卡组已满
+        ds_map_destroy(deck_entry);
+        return false;
+    }
+
+    // 覆盖旧槽位前清理旧数据
+    var old = global.selected_deck[| idx];
+    if (old != global.deck_empty_slot && ds_exists(old, ds_type_map)) {
+        ds_map_destroy(old);
+    }
+    global.selected_deck[| idx] = deck_entry;
+    return true;
+}
+
+/// @function deck_slot_max()
+/// @desc 出战卡组槽位总数（= 已解锁的 max_slot；无存档兜底 21）
+function deck_slot_max() {
+    if (variable_global_exists("save_data") && !is_undefined(global.save_data)
+        && variable_struct_exists(global.save_data, "unlocked_items")) {
+        return global.save_data.unlocked_items.max_slot;
+    }
+    return 21;
+}
+
+/// @function deck_empty_slot_ensure()
+/// @desc 确保全局空槽标记 ds_map 存在（幂等；card_id=""）
+function deck_empty_slot_ensure() {
+    if (!variable_global_exists("deck_empty_slot") || is_undefined(global.deck_empty_slot) || global.deck_empty_slot == -1) {
+        global.deck_empty_slot = ds_map_create();
+        global.deck_empty_slot[? "card_id"] = "";
+        global.deck_empty_slot[? "shape"] = -1;
+        global.deck_empty_slot[? "data"] = noone;
+    }
+    return global.deck_empty_slot;
+}
+
+/// @function deck_ensure_size()
+/// @desc 把 selected_deck 补齐到 max_slot 长度（不足追加以 [deck_empty_slot] 占位）
+function deck_ensure_size() {
+    deck_empty_slot_ensure();
+    var max = deck_slot_max();
+    while (ds_list_size(global.selected_deck) < max) {
+        ds_list_add(global.selected_deck, global.deck_empty_slot);
+    }
+}
+
+/// @function deck_slot_is_empty(i)
+/// @desc 判断槽位 i 是否为空（越界/标记/undefined/noone/card_id=="" 均判空）
+function deck_slot_is_empty(i) {
+    if (i < 0 || i >= ds_list_size(global.selected_deck)) return true;
+    var e = global.selected_deck[| i];
+    if (e == global.deck_empty_slot) return true;
+    if (e == undefined || e == noone) return true;
+    return (e[? "card_id"] == "");
+}
+
+/// @function deck_slot_count()
+/// @desc 当前非空卡数量（= 实际出战卡数）
+function deck_slot_count() {
+    deck_ensure_size();
+    var n = 0;
+    var max = ds_list_size(global.selected_deck);
+    for (var i = 0; i < max; i++) {
+        if (!deck_slot_is_empty(i)) n++;
+    }
+    return n;
+}
+
+/// @function deck_slot_first_empty()
+/// @desc 返回最靠前空槽下标，无空槽返回 -1
+function deck_slot_first_empty() {
+    deck_ensure_size();
+    var max = ds_list_size(global.selected_deck);
+    for (var i = 0; i < max; i++) {
+        if (deck_slot_is_empty(i)) return i;
+    }
+    return -1;
+}
+
+/// @function remove_from_deck(i)
+/// @desc 移除指定槽位的卡，槽位保留为空（不补位）
+function remove_from_deck(i) {
+    deck_ensure_size();
+    if (i < 0 || i >= ds_list_size(global.selected_deck)) return;
+    if (deck_slot_is_empty(i)) return;
+    var old = global.selected_deck[| i];
+    if (old != global.deck_empty_slot && ds_exists(old, ds_type_map)) {
+        ds_map_destroy(old);
+    }
+    global.selected_deck[| i] = global.deck_empty_slot;
+}
+
+/// @function clear_deck()
+/// @desc 清空整个卡组（所有槽位置空，长度保留 max_slot）
+function clear_deck() {
+    var max = deck_slot_max();
+    ds_list_clear(global.selected_deck);
+    deck_empty_slot_ensure();
+    for (var i = 0; i < max; i++) {
+        ds_list_add(global.selected_deck, global.deck_empty_slot);
+    }
 }

--- a/scripts/create_battle_slots/create_battle_slots.gml
+++ b/scripts/create_battle_slots/create_battle_slots.gml
@@ -1,18 +1,21 @@
 /// @function create_battle_slots()
-/// @desc 根据当前卡组创建战斗卡槽
+/// @desc 根据当前卡组创建战斗卡槽（空槽跳过，非空卡按顺序排布）
 function create_battle_slots() {
     var start_x = 535;
     var y_pos = 90;
     var x_spacing = 90;
 	var y_spacing = 118;
     
-    for(var i = 0; i < ds_list_size(global.selected_deck); i++) {
+    var n = 0;
+    var max_slot = deck_slot_max();
+    for(var i = 0; i < max_slot; i++) {
+        if (deck_slot_is_empty(i)) continue; // 跳过空槽
         var deck_entry = global.selected_deck[| i];
         var card_data = deck_entry[? "data"];
         var inst = noone
-		if i <= 14{
+		if n <= 14{
 			inst = instance_create_depth(
-            start_x + i * x_spacing, 
+            start_x + n * x_spacing, 
             y_pos, 
             -5, 
             obj_card_slot
@@ -21,7 +24,7 @@ function create_battle_slots() {
 		else{
 			inst = instance_create_depth(
             start_x + 14 * x_spacing, 
-            y_pos+(i-14)*y_spacing, 
+            y_pos+(n-14)*y_spacing, 
             -5, 
             obj_card_slot
         )
@@ -33,10 +36,11 @@ function create_battle_slots() {
         inst.card_spr = card_data[? "sprite"];
 		inst.place_preview = card_data[? "place_preview"]
         inst.description = card_data[? "description"];
-        inst.slot_index = i + 1;
+        inst.slot_index = n + 1;
 		inst.card_id = deck_entry[? "card_id"];
         inst.shape = deck_entry[? "shape"]; // 存储形态信息
 		inst.depth = -2000
 		//show_debug_message("植物卡槽已生成，id：" + inst.card_id)
+        n++
     }
 }

--- a/scripts/deck_init/deck_init.gml
+++ b/scripts/deck_init/deck_init.gml
@@ -1,4 +1,5 @@
 function deck_init(){
 	global.player_deck = ds_list_create();
-	global.selected_deck = ds_list_create(); 
+	global.selected_deck = ds_list_create();
+	deck_empty_slot_ensure();
 }

--- a/scripts/load_custom_deck/load_custom_deck.gml
+++ b/scripts/load_custom_deck/load_custom_deck.gml
@@ -28,9 +28,9 @@ function load_custom_deck(deck_index) {
 }
 
 function save_to_custom_deck(deck_index,deck_name){
-	var max = deck_slot_max()
-	var card_arr = array_create(max, "")
-	for(var i = 0; i < max;i++){
+	var _max = deck_slot_max()
+	var card_arr = array_create(_max, "")
+	for(var i = 0; i < _max;i++){
 		if (!deck_slot_is_empty(i)){
 			card_arr[i] = global.selected_deck[| i][? "card_id"]
 		}

--- a/scripts/load_custom_deck/load_custom_deck.gml
+++ b/scripts/load_custom_deck/load_custom_deck.gml
@@ -2,17 +2,22 @@
 /// @desc 加载自定义卡组（未来从存档/菜单读取）
 /// @param {real} deck_index 卡组ID
 function load_custom_deck(deck_index) {
-    // 清空当前卡组
+    // 清空当前卡组并按槽位重建
     ds_list_clear(global.selected_deck);
-    
-    // 添加新卡牌
-    for(var i = 0; i < array_length(global.save_data.saved_decks[deck_index].card_id); i++) {
-        var info = get_card_info(global.save_data.saved_decks[deck_index].card_id[i]);
+    deck_ensure_size();
+
+    // 添加新卡牌（保留存档槽位；旧紧凑档顺次填前 N 槽自动兼容）
+    var card_ids = global.save_data.saved_decks[deck_index].card_id;
+    var len = array_length(card_ids);
+    for(var i = 0; i < len; i++) {
+        var cid = card_ids[i];
+        if (cid == "" || is_undefined(cid) || cid == noone) continue; // 跳过空槽
+        var info = get_card_info(cid);
         if (info != false) {
-            add_to_deck(global.save_data.saved_decks[deck_index].card_id[i], info.shape);
+            add_to_deck(cid, info.shape, i);
         }
     }
-    
+
     // 重新创建卡槽（需在战斗房间调用）
     if (instance_exists(obj_battle)) {
         // 先删除旧卡槽
@@ -23,10 +28,13 @@ function load_custom_deck(deck_index) {
 }
 
 function save_to_custom_deck(deck_index,deck_name){
-	array_delete(global.save_data.saved_decks[deck_index].card_id,0,21)
-	var length = ds_list_size(global.selected_deck)
-	for(var i = 0; i < length;i++){
-		global.save_data.saved_decks[deck_index].card_id[i] = global.selected_deck[| i][? "card_id"]
+	var max = deck_slot_max()
+	var card_arr = array_create(max, "")
+	for(var i = 0; i < max;i++){
+		if (!deck_slot_is_empty(i)){
+			card_arr[i] = global.selected_deck[| i][? "card_id"]
+		}
 	}
+	global.save_data.saved_decks[deck_index].card_id = card_arr
 	save_file(global.save_slot)
 }


### PR DESCRIPTION
需求（issue #54）
备战房选卡槽支持空槽：更换靠前位置的卡不再需要把后面所有卡全取下。

行为
- 点击槽内卡片 → 该槽直接空置（其余槽位不动，不再整列前移补位）
- 点击卡库卡片 → 自动填入最靠前空槽
- 示例：[A,B,C] → 点掉A → [_ ,B,C] → 点新卡X → 填槽1 → [X,B,C]

实现
- selected_deck 改为固定长度槽位（= max_slot），空槽用共享标记占位（card_id=""）
- scripts/add_to_deck/add_to_deck.gml 新增 deck_slot_max / deck_ensure_size / deck_slot_is_empty / deck_slot_count / deck_slot_first_empty / remove_from_deck / clear_deck，并重写 add_to_deck（支持 slot_index 精确填槽用于读档还原）
- 战斗、火焰、铲子、开始按钮等按非空卡数计数并跳过空槽
- 存档改为固定槽位（空槽记空串），旧紧凑存档自动按前 N 槽兼容加载

closes #54